### PR TITLE
Modify highlight and key bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "activationEvents": [
     "onCommand:crayons.highlight",
-    "onCommand:crayons.clear"
+    "onCommand:crayons.clear",
+    "onCommand:crayons.clearAll"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -38,12 +39,16 @@
       {
         "command": "crayons.clear",
         "title": "Crayons: Clear"
+      },
+      {
+        "command": "crayons.clearAll",
+        "title": "Crayons: Clear All Highlights"
       }
     ],
     "keybindings":[
       {
         "command": "crayons.highlight",
-        "key": "shift+f1"
+        "key": "semicolon k"
       },
       {
         "command": "crayons.clear",

--- a/src/crayons.ts
+++ b/src/crayons.ts
@@ -20,17 +20,38 @@ export class Crayons {
   }
 
   public highlight() {
-    this.decorate(this.getSelectedWord());
+    const word = this.getSelectedWord();
+    if (this.words.indexOf(word) !== -1) {
+      // Word is already highlighted, remove it
+      this.removeHighlight(word);
+    } else {
+      // Word is not highlighted, add it
+      this.decorate(word);
+    }
   }
 
   public refresh() {
-    this.words.forEach(word => this.decorate(word));
+    // Clear all decorations first
+    this.decorationTypes.forEach(decorationType =>
+      this.editor.setDecorations(decorationType, []));
+    
+    // Re-apply all highlights
+    this.words.forEach((word, index) => this.decorateWithIndex(word, index));
   }
 
   public clear() {
     this.words = [];
     this.decorationTypes.forEach(decorationType =>
       this.editor.setDecorations(decorationType, []));
+  }
+
+  public removeHighlight(word: string) {
+    const idx = this.words.indexOf(word);
+    if (idx !== -1) {
+      this.words.splice(idx, 1);
+      // Re-apply all remaining highlights to maintain color consistency
+      this.refresh();
+    }
   }
 
   public updateEditor(editor: TextEditor) {
@@ -46,6 +67,14 @@ export class Crayons {
   }
 
   private decorate(word: string) {
+    if (this.words.indexOf(word) === -1) {
+      this.words.push(word);
+    }
+    const idx = this.words.indexOf(word);
+    this.decorateWithIndex(word, idx);
+  }
+
+  private decorateWithIndex(word: string, wordIndex: number) {
     const regex = RegExp(word, 'g');
     let decorations: DecorationOptions[] = [];
     let match;
@@ -59,17 +88,12 @@ export class Crayons {
       decorations.push(decoration);
     }
 
-    if (this.words.indexOf(word) === -1) {
-      this.words.push(word);
+    let decorationIdx = wordIndex;
+    if (decorationIdx >= this.decorationTypes.length) {
+      decorationIdx %= this.decorationTypes.length;
     }
 
-    let idx = this.words.indexOf(word);
-
-    if (idx >= this.decorationTypes.length) {
-      idx %= this.decorationTypes.length;
-    }
-
-    this.editor.setDecorations(this.decorationTypes[idx], decorations);
+    this.editor.setDecorations(this.decorationTypes[decorationIdx], decorations);
   }
 
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,16 @@ export function activate(context: vscode.ExtensionContext) {
         getCrayons(editor).clear();
       }
     ),
+    vscode.commands.registerCommand(
+      "crayons.clearAll",
+      () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+          return;
+        }
+        getCrayons(editor).clear();
+      }
+    ),
     vscode.workspace.onDidChangeTextDocument((event) => {
       console.log("onDidChangeTextDocument", event);
     }),


### PR DESCRIPTION
Implement highlight toggle, add clear all command, and update default keybinding to `;+k`.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b74dd2a-1382-447d-89af-a3376c0f8781">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b74dd2a-1382-447d-89af-a3376c0f8781">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

