### PR TITLE
Navigate between same-color highlighted blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crayons",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "crayons",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "devDependencies": {
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.0.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
     "onCommand:crayons.highlight",
     "onCommand:crayons.clear",
     "onCommand:crayons.clearAll",
-    "onCommand:crayons.highlightManual"
+    "onCommand:crayons.highlightManual",
+    "onCommand:crayons.navigateNext",
+    "onCommand:crayons.navigatePrevious",
+    "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -48,6 +51,14 @@
       {
         "command": "crayons.highlightManual",
         "title": "Crayons: Highlight Manual Input"
+      },
+      {
+        "command": "crayons.navigateNext",
+        "title": "Crayons: Navigate to Next Highlight"
+      },
+      {
+        "command": "crayons.navigatePrevious",
+        "title": "Crayons: Navigate to Previous Highlight"
       }
     ],
     "keybindings":[
@@ -62,6 +73,16 @@
       {
         "command": "crayons.highlightManual",
         "key": "ctrl+shift+f2"
+      },
+      {
+        "command": "crayons.navigateNext",
+        "key": "n",
+        "when": "editorTextFocus && crayons.hasHighlights"
+      },
+      {
+        "command": "crayons.navigatePrevious",
+        "key": "shift+n",
+        "when": "editorTextFocus && crayons.hasHighlights"
       }
     ],
     "configuration": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,6 +44,26 @@ export function activate(context: vscode.ExtensionContext) {
         await getCrayons(editor).highlightManual();
       }
     ),
+    vscode.commands.registerCommand(
+      "crayons.navigateNext",
+      () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+          return;
+        }
+        getCrayons(editor).navigateToNext();
+      }
+    ),
+    vscode.commands.registerCommand(
+      "crayons.navigatePrevious",
+      () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+          return;
+        }
+        getCrayons(editor).navigateToPrevious();
+      }
+    ),
     vscode.workspace.onDidChangeTextDocument((event) => {
       console.log("onDidChangeTextDocument", event);
     }),


### PR DESCRIPTION
Add keyboard navigation (n/N) for highlighted regions with priority over Vim search.

---
<a href="https://cursor.com/background-agent?bcId=bc-b02b55bf-7429-4c9f-9c8f-26ae4c36f495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b02b55bf-7429-4c9f-9c8f-26ae4c36f495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

